### PR TITLE
Add support for searching all drives

### DIFF
--- a/examples/file_get
+++ b/examples/file_get
@@ -21,8 +21,16 @@ file_id = ARGV[0] || '1MNb_59W87lj75-9HqrEQoFBdrQiNl96rDlRy87sDIjs'
 # fields = 'id, name, parents, web_view_link'
 fields = '*'
 
+# If `supports_all_drives` is false or not specified, the request will fail if
+# the file is in a shared drive.
+#
+# See [Search for files & folders](https://developers.google.com/drive/api/v3/search-files)
+# for more information about how to search for files in shared drives.
+#
+supports_all_drives = true
+
 begin
-  file = drive_service.get_file(file_id, fields:)
+  file = drive_service.get_file(file_id, fields:, supports_all_drives:)
   puts JSON.pretty_generate(file.to_h)
 rescue StandardError => e
   puts "An error occurred: #{e.message}"

--- a/examples/file_search
+++ b/examples/file_search
@@ -33,7 +33,7 @@ files = []
 # Limiting to 5 for this example, normally this would be a lot higher
 # (default is 100)
 #
-page_size = 5
+page_size = 100
 
 # Signal to get first page of results
 #
@@ -66,8 +66,16 @@ q = 'trashed=false'
 # fields = 'nextPageToken, files(id, name, parents, web_view_link)'
 fields = '*'
 
+# If `include_items_from_all_drives` is false or omitted, only files from the user's
+# default drive are returned.
+#
+include_items_from_all_drives = true
+
 loop do
-  file_list = @drive_service.list_files(q:, fields:, page_token:, page_size:)
+  file_list = @drive_service.list_files(
+    q:, fields:, include_items_from_all_drives:,
+    page_token:, page_size:
+  )
   files += file_list.files.map(&:to_h)
   # Stop looping if there are no more pages
   break unless (page_token = file_list.next_page_token)


### PR DESCRIPTION
This pull request adds support for searching all drives in the Google Drive API. 

By setting the `supports_all_drives` parameter to `true` in the `list_files` method, the request will no longer fail if the file is in a shared drive. This allows users to search for files in shared drives as well. 

Additionally, the `include_items_from_all_drives` parameter is set to `true` in the `list_files` method, which ensures that files from all drives are returned, not just the user's default drive. This is useful when searching for files across multiple drives.