### PR TITLE
Release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ Changes for each release are listed in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/) for its releases.
 
+## v0.2.1 (2023-12-05)
+
+[Full Changelog](https://github.com/main-branch/drive_v3/compare/v0.2.0..v0.2.1)
+
+Changes since v0.2.0:
+
+* f1b82bd Update examples to include the supports_all_drives parameter (#6)
+* b26f1fa Release v0.2.0 (#5)
+
 ## v0.2.0 (2023-12-04)
 
 [Full Changelog](https://github.com/main-branch/drive_v3/compare/v0.1.0..v0.2.0)

--- a/lib/drive_v3/version.rb
+++ b/lib/drive_v3/version.rb
@@ -2,5 +2,5 @@
 
 module DriveV3
   # The version of this gem
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end


### PR DESCRIPTION
# Release PR

## v0.2.1 (2023-12-05)

[Full Changelog](https://github.com/main-branch/drive_v3/compare/v0.2.0..v0.2.1)

Changes since v0.2.0:

* f1b82bd Update examples to include the supports_all_drives parameter (#6)
* b26f1fa Release v0.2.0 (#5)
