### PR TITLE
Add links to other gems in the Google API helpers series

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,6 +55,6 @@ jobs:
       - name: Report test coverage
         uses: paambaati/codeclimate-action@v3.2.0
         env:
-          CC_TEST_REPORTER_ID: b79e3e5c15467ab7753d3dfbe521e07d79f8e1af50e52428f0281e4f8c4ed3b8
+          CC_TEST_REPORTER_ID: d9fb05c3480afd6287a0e6f97622d84fc33b9573b61ad6957188d3ce647f42b4
         with:
           coverageLocations: ${{github.workspace}}/coverage/lcov/*.lcov:lcov

--- a/README.md
+++ b/README.md
@@ -9,6 +9,16 @@
 
 Unofficial helpers and extensions for the Google Drive V3 API
 
+Gems in the Google API helper, extensions, and examples series:
+
+* [discovery_v1](https://github.com/main-branch/discovery_v1)
+* [drive_v3](https://github.com/main-branch/drive_v3)
+* [sheets_v4](https://github.com/main-branch/sheets_v4)
+
+## Contents
+
+op* [Contents](#contents)
+* [Contents](#contents)
 * [Installation](#installation)
 * [Examples](#examples)
 * [Important links for programming Google Drive](#important-links-for-programming-google-drive)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Gems in the Google API helper, extensions, and examples series:
 
 ## Contents
 
-op* [Contents](#contents)
 * [Contents](#contents)
 * [Installation](#installation)
 * [Examples](#examples)


### PR DESCRIPTION
In the project's README.md, add links to all the gems in the Google API helper, extensions, and examples series:

* [discovery_v1](https://github.com/main-branch/discovery_v1)
* [drive_v3](https://github.com/main-branch/drive_v3)
* [sheets_v4](https://github.com/main-branch/sheets_v4)