### PR TITLE
Fix rubocop Gemspec/AddRuntimeDependency offense

### DIFF
--- a/drive_v3.gemspec
+++ b/drive_v3.gemspec
@@ -47,10 +47,10 @@ Gem::Specification.new do |spec|
     spec.add_development_dependency 'yardstick', '~> 0.9'
   end
 
-  spec.add_runtime_dependency 'activesupport', '~> 7.0'
+  spec.add_dependency 'activesupport', '~> 7.0'
   spec.add_development_dependency 'github_pages_rake_tasks', '~> 0.1'
-  spec.add_runtime_dependency 'google-apis-drive_v3', '~> 0.26'
-  spec.add_runtime_dependency 'googleauth'
-  spec.add_runtime_dependency 'json_schemer', '~> 2.0'
-  spec.add_runtime_dependency 'rltk', '~> 3.0'
+  spec.add_dependency 'google-apis-drive_v3', '~> 0.26'
+  spec.add_dependency 'googleauth'
+  spec.add_dependency 'json_schemer', '~> 2.0'
+  spec.add_dependency 'rltk', '~> 3.0'
 end


### PR DESCRIPTION
This pull request fixes a rubocop offense in the Gemspec file by changing `add_runtime_dependency` to `add_dependency`.