### PR TITLE
Update continuous integration and experimental ruby builds

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -1,28 +1,39 @@
-name: CI Build
+name: Continuous Integration
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
 
   pull_request:
-     branches: [ main ]
+    branches: [main]
+
+  workflow_dispatch:
+
+# Supported platforms / Ruby versions:
+#  - Ubuntu: MRI (3.1, 3.2, 3.3), TruffleRuby (24), JRuby (9.4)
+#  - Windows: MRI (3.1), JRuby (9.4)
 
 jobs:
   build:
+    name: Ruby ${{ matrix.ruby }} on ${{ matrix.operating-system }}
+
+    runs-on: ${{ matrix.operating-system }}
     continue-on-error: true
 
     strategy:
+      fail-fast: false
       matrix:
-        ruby: ['3.1', '3.2', head]
+        ruby: ["3.1", "3.2", "3.3", "jruby-9.4", "truffleruby-24"]
         operating-system: [ubuntu-latest]
-
-    name: Ruby ${{ matrix.ruby }} on ${{ matrix.operating-system }}
-    runs-on: ${{ matrix.operating-system }}
+        include:
+          - ruby: "3.1"
+            operating-system: windows-latest
+          - ruby: "jruby-9.4"
+            operating-system: windows-latest
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Initialize Ruby
         uses: ruby/setup-ruby@v1
@@ -34,14 +45,14 @@ jobs:
         run: bundle exec rake
 
   coverage:
-    needs: [ build ]
-    runs-on: ubuntu-latest
-
     name: Report test coverage to CodeClimate
+
+    needs: [build]
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Initialize Ruby
         uses: ruby/setup-ruby@v1
@@ -49,12 +60,10 @@ jobs:
           ruby-version: 3.1
           bundler-cache: true
 
-      - name: Run tests
-        run: bundle exec rake spec
-
       - name: Report test coverage
-        uses: paambaati/codeclimate-action@v3.2.0
+        uses: paambaati/codeclimate-action@v9
         env:
           CC_TEST_REPORTER_ID: d9fb05c3480afd6287a0e6f97622d84fc33b9573b61ad6957188d3ce647f42b4
         with:
+          coverageCommand: bundle exec rake spec
           coverageLocations: ${{github.workspace}}/coverage/lcov/*.lcov:lcov

--- a/.github/workflows/experimental_ruby_builds.yml
+++ b/.github/workflows/experimental_ruby_builds.yml
@@ -1,0 +1,46 @@
+name: Experimental Ruby Builds
+
+on:
+  push:
+    branches: [main]
+
+  workflow_dispatch:
+
+# Experimental platforms / Ruby versions:
+#  - Ubuntu: MRI (head), TruffleRuby (head), JRuby (head)
+#  - Windows: MRI (head), JRuby (head)
+
+jobs:
+  build:
+    name: Ruby ${{ matrix.ruby }} on ${{ matrix.operating-system }}
+    
+    runs-on: ${{ matrix.operating-system }}
+    continue-on-error: true
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - ruby: head
+            operating-system: ubuntu-latest
+          - ruby: head
+            operating-system: windows-latest
+          - ruby: truffleruby-head
+            operating-system: ubuntu-latest
+          - ruby: jruby-head
+            operating-system: ubuntu-latest
+          - ruby: jruby-head
+            operating-system: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+
+      - name: Run rake
+        run: bundle exec rake

--- a/drive_v3.gemspec
+++ b/drive_v3.gemspec
@@ -32,12 +32,16 @@ Gem::Specification.new do |spec|
   spec.bindir = 'exe'
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
+  spec.requirements = [
+    'Platform: Mac, Linux, or Windows',
+    'Ruby: MRI 3.1 or later, TruffleRuby 24 or later, or JRuby 9.4 or later'
+  ]
 
   spec.add_development_dependency 'bundler-audit', '~> 0.9'
-  spec.add_development_dependency 'create_github_release', '~> 1.0'
-  spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rspec', '~> 3.12'
-  spec.add_development_dependency 'rubocop', '~> 1.48'
+  spec.add_development_dependency 'create_github_release', '~> 1.5'
+  spec.add_development_dependency 'rake', '~> 13.2'
+  spec.add_development_dependency 'rspec', '~> 3.13'
+  spec.add_development_dependency 'rubocop', '~> 1.66'
   spec.add_development_dependency 'simplecov', '~> 0.22'
   spec.add_development_dependency 'simplecov-lcov', '~> 0.8'
 
@@ -49,8 +53,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activesupport', '~> 7.0'
   spec.add_development_dependency 'github_pages_rake_tasks', '~> 0.1'
-  spec.add_dependency 'google-apis-drive_v3', '~> 0.26'
+  spec.add_dependency 'google-apis-drive_v3', '~> 0.55'
   spec.add_dependency 'googleauth'
-  spec.add_dependency 'json_schemer', '~> 2.0'
+  spec.add_dependency 'json_schemer', '~> 2.3'
   spec.add_dependency 'rltk', '~> 3.0'
 end


### PR DESCRIPTION
Update continuous integration and experimental Ruby builds making the following changes:

* Change supported platforms / Ruby versions
  * Continuous integration platforms / Ruby versions:
    * Ubuntu: MRI (3.1, 3.2, 3.3), TruffleRuby (24), JRuby (9.4)
    * Windows: MRI (3.1), JRuby (9.4)
  * Experimental platforms / Ruby versions:
    * Ubuntu: MRI (head), TruffleRuby (head), JRuby (head)
    * Windows: MRI (head), JRuby (head)

* Update continuous integration and experimental ruby builds to use the same workflow for all projects (including possibly renaming the workflow file name and name)

* Update the minimally required Ruby in the project’s gemspec and .rubocop.yml

* Update dependencies to latest

* Auto correct new Rubocop offenses