### PR TITLE
Integrate simplecov-rspec into the project

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -31,6 +31,9 @@ jobs:
           - ruby: "jruby-9.4"
             operating-system: windows-latest
 
+    env:
+      JRUBY_OPTS: --debug
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -49,6 +52,9 @@ jobs:
 
     needs: [build]
     runs-on: ubuntu-latest
+
+    env:
+      JRUBY_OPTS: --debug
 
     steps:
       - name: Checkout

--- a/.github/workflows/experimental_ruby_builds.yml
+++ b/.github/workflows/experimental_ruby_builds.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build:
     name: Ruby ${{ matrix.ruby }} on ${{ matrix.operating-system }}
-    
+
     runs-on: ${{ matrix.operating-system }}
     continue-on-error: true
 
@@ -31,6 +31,9 @@ jobs:
             operating-system: ubuntu-latest
           - ruby: jruby-head
             operating-system: windows-latest
+
+    env:
+      JRUBY_OPTS: --debug
 
     steps:
       - name: Checkout

--- a/drive_v3.gemspec
+++ b/drive_v3.gemspec
@@ -44,6 +44,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 1.66'
   spec.add_development_dependency 'simplecov', '~> 0.22'
   spec.add_development_dependency 'simplecov-lcov', '~> 0.8'
+  spec.add_development_dependency 'simplecov-rspec', '~> 0.3'
 
   unless RUBY_PLATFORM == 'java'
     spec.add_development_dependency 'redcarpet', '~> 3.6'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,113 +12,22 @@ RSpec.configure do |config|
   end
 end
 
-# Setup simplecov
-
+# SimpleCov configuration
+#
 require 'simplecov'
 require 'simplecov-lcov'
-require 'json'
+require 'simplecov-rspec'
 
-SimpleCov.formatters = [SimpleCov::Formatter::HTMLFormatter, SimpleCov::Formatter::LcovFormatter]
+def ci_build? = ENV.fetch('GITHUB_ACTIONS', 'false') == 'true'
 
-# Return `true` if the environment variable is set to a truthy value
-#
-# @example
-#   env_true?('COV_SHOW_UNCOVERED')
-#
-# @param name [String] the name of the environment variable
-# @return [Boolean]
-#
-def env_true?(name)
-  value = ENV.fetch(name, '').downcase
-  %w[yes on true 1].include?(value)
+if ci_build?
+  SimpleCov.formatters = [
+    SimpleCov::Formatter::HTMLFormatter,
+    SimpleCov::Formatter::LcovFormatter
+  ]
 end
 
-# Return `true` if the environment variable is NOT set to a truthy value
-#
-# @example
-#   env_false?('COV_NO_FAIL')
-#
-# @param name [String] the name of the environment variable
-# @return [Boolean]
-#
-def env_false?(name)
-  !env_true?(name)
-end
-
-# Return `true` if the the test run should fail if the coverage is below the threshold
-#
-# @return [Boolean]
-#
-def fail_on_low_coverage?
-  !(RSpec.configuration.dry_run? || env_true?('COV_NO_FAIL'))
-end
-
-# Return `true` if the the test run should show the lines not covered by tests
-#
-# @return [Boolean]
-#
-def show_lines_not_covered?
-  env_true?('COV_SHOW_UNCOVERED')
-end
-
-# Report if the test coverage was below the configured threshold
-#
-# The threshold is configured by setting the `test_coverage_threshold` variable
-# in this file.
-#
-# Example:
-#
-# ```Ruby
-# test_coverage_threshold = 100
-# ```
-#
-# Coverage below the threshold will cause the rspec run to fail unless the
-# `COV_NO_FAIL` environment variable is set to TRUE.
-#
-# ```Shell
-# COV_NO_FAIL=TRUE rspec
-# ```
-#
-# Example of running the tests in an infinite loop writing failures to `fail.txt`:
-#
-# ```Shell
-# while true; do COV_NO_FAIL=TRUE rspec >> fail.txt; done
-# ````
-#
-# The lines missing coverage will be displayed if the `COV_SHOW_UNCOVERED`
-# environment variable is set to TRUE.
-#
-# ```Shell
-# COV_SHOW_UNCOVERED=TRUE rspec
-# ```
-#
-test_coverage_threshold = 100
-
-SimpleCov.at_exit do
-  SimpleCov.result.format!
-  # rubocop:disable Style/StderrPuts
-  if SimpleCov.result.covered_percent < test_coverage_threshold
-    $stderr.puts
-    $stderr.print 'FAIL: ' if fail_on_low_coverage?
-    $stderr.puts "RSpec Test coverage fell below #{test_coverage_threshold}%"
-
-    if show_lines_not_covered?
-      $stderr.puts "\nThe following lines were not covered by tests:\n"
-      SimpleCov.result.files.each do |source_file| # SimpleCov::SourceFile
-        source_file.missed_lines.each do |line| # SimpleCov::SourceFile::Line
-          $stderr.puts "  .#{source_file.project_filename}:#{line.number}"
-        end
-      end
-    end
-
-    $stderr.puts
-
-    exit 1 if fail_on_low_coverage?
-  end
-  # rubocop:enable Style/StderrPuts
-end
-
-SimpleCov.start
+SimpleCov::RSpec.start(list_uncovered_lines: ci_build?)
 
 # Make sure to require your project AFTER SimpleCov.start
 #


### PR DESCRIPTION
simplecov-rspec is a Ruby gem that integrates SimpleCov with RSpec to ensure your tests meet a minimum coverage threshold. It enhances your test suite by automatically failing tests when coverage falls below a specified threshold and, optionally, listing uncovered lines to help you improve coverage.