### PR TITLE
Release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ Changes for each release are listed in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/) for its releases.
 
+## v0.3.0 (2024-10-11)
+
+[Full Changelog](https://github.com/main-branch/drive_v3/compare/v0.2.1..v0.3.0)
+
+Changes since v0.2.1:
+
+* c9aed1f build: remove semver pr label check
+* eaac868 build: enforce conventional commit message formatting
+* 5f44bc1 Use shared Rubocop config (#20)
+* 52fb8ad Update copyright notice in this project (#19)
+* c8b8973 Update links in gemspec
+* be94ccb Add Slack badge for this project in README
+* b17e527 Use standard badges at the top of the README
+* d200a3e Update yardopts with new standard options
+* 322805c Standardize YARD and Markdown Lint configurations
+* 865eed7 Set JRuby --debug option when running tests in GitHub Actions workflows
+* d675a2e Integrate simplecov-rspec into the project
+* be896ab Update continuous integration and experimental ruby builds
+* 6e5487a Enforce the use of semver tags on PRs
+* 03e23b3 Auto correct rubocop Gemspec/AddRuntimeDependency offense
+* 0c9230b Add links to other gems in the Google API helpers series (#8)
+
 ## v0.2.1 (2023-12-05)
 
 [Full Changelog](https://github.com/main-branch/drive_v3/compare/v0.2.0..v0.2.1)

--- a/lib/drive_v3/version.rb
+++ b/lib/drive_v3/version.rb
@@ -2,5 +2,5 @@
 
 module DriveV3
   # The version of this gem
-  VERSION = '0.2.1'
+  VERSION = '0.3.0'
 end


### PR DESCRIPTION
# Release PR

## v0.3.0 (2024-10-11)

[Full Changelog](https://github.com/main-branch/drive_v3/compare/v0.2.1..v0.3.0)

Changes since v0.2.1:

* c9aed1f build: remove semver pr label check
* eaac868 build: enforce conventional commit message formatting
* 5f44bc1 Use shared Rubocop config (#20)
* 52fb8ad Update copyright notice in this project (#19)
* c8b8973 Update links in gemspec
* be94ccb Add Slack badge for this project in README
* b17e527 Use standard badges at the top of the README
* d200a3e Update yardopts with new standard options
* 322805c Standardize YARD and Markdown Lint configurations
* 865eed7 Set JRuby --debug option when running tests in GitHub Actions workflows
* d675a2e Integrate simplecov-rspec into the project
* be896ab Update continuous integration and experimental ruby builds
* 6e5487a Enforce the use of semver tags on PRs
* 03e23b3 Auto correct rubocop Gemspec/AddRuntimeDependency offense
* 0c9230b Add links to other gems in the Google API helpers series (#8)
