### PR TITLE
fix: do not trigger build workflows after merging to main or for release PRs

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -1,9 +1,6 @@
 name: Continuous Integration
 
 on:
-  push:
-    branches: [main]
-
   pull_request:
     branches: [main]
 
@@ -14,13 +11,13 @@ env:
   # results from JRuby are complete.
   JRUBY_OPTS: --debug
 
-# Supported platforms / Ruby versions:
-#  - Ubuntu: MRI (3.1, 3.2, 3.3), TruffleRuby (24), JRuby (9.4)
-#  - Windows: MRI (3.1), JRuby (9.4)
-
 jobs:
   build:
     name: Ruby ${{ matrix.ruby }} on ${{ matrix.operating-system }}
+
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && !startsWith(github.event.pull_request.head.ref, 'release-please--'))
 
     runs-on: ${{ matrix.operating-system }}
     continue-on-error: true
@@ -28,13 +25,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.1", "3.2", "3.3", "jruby-9.4", "truffleruby-24"]
+        ruby: ["3.1", "3.4"]
         operating-system: [ubuntu-latest]
-        include:
-          - ruby: "3.1"
-            operating-system: windows-latest
-          - ruby: "jruby-9.4"
-            operating-system: windows-latest
 
     env:
       JRUBY_OPTS: --debug

--- a/.github/workflows/enforce_conventional_commits.yml
+++ b/.github/workflows/enforce_conventional_commits.yml
@@ -9,6 +9,10 @@ jobs:
   commit-lint:
     name: Verify Conventional Commits
 
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && !startsWith(github.event.pull_request.head.ref, 'release-please--'))
+
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/experimental_ruby_builds.yml
+++ b/.github/workflows/experimental_ruby_builds.yml
@@ -1,9 +1,6 @@
 name: Experimental Ruby Builds
 
 on:
-  push:
-    branches: [main]
-
   workflow_dispatch:
 
 env:
@@ -22,23 +19,28 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     continue-on-error: true
 
+    env:
+      FAIL_ON_LOW_COVERAGE: ${{ matrix.fail_on_low_coverage }}
+
     strategy:
       fail-fast: false
       matrix:
         include:
+          - ruby: "3.1"
+            operating-system: windows-latest
+            fail_on_low_coverage: "false"
           - ruby: head
             operating-system: ubuntu-latest
-          - ruby: head
-            operating-system: windows-latest
-          - ruby: truffleruby-head
+            fail_on_low_coverage: "false"
+          - ruby: "truffleruby-24"
             operating-system: ubuntu-latest
-          - ruby: jruby-head
+            fail_on_low_coverage: "false"
+          - ruby: "jruby-9.4"
             operating-system: ubuntu-latest
-          - ruby: jruby-head
+            fail_on_low_coverage: "false"
+          - ruby: "jruby-9.4"
             operating-system: windows-latest
-
-    env:
-      JRUBY_OPTS: --debug
+            fail_on_low_coverage: "false"
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Since all merges to the main branch must be a fast-forward rebase, CI
builds should not be run when merged to main. They are run via the
pull request before merging.

The continuous_integration workflow should be triggered for pull requests
targeting main.

The experimental_ruby_builds workflow should only be triggered manually via
the GitHub UI.

Move unneeded builds from continuous_integration to experimental_ruby_builds

There is not a good reason to have a specific builds in the
continuous_integration workflow on Windows, or using JRuby or TruffleRuby.